### PR TITLE
Fix for Allegro Common Lisp

### DIFF
--- a/cltl2.lisp
+++ b/cltl2.lisp
@@ -13,6 +13,7 @@
         #+allegro #:sys
         #+ecl #:si
         #+abcl #:lisp)
+  #+allegro (:import-from #:excl #:compiler-let)
   (:export #:compiler-let
            #:variable-information
            #:function-information
@@ -21,3 +22,16 @@
            #:define-declaration
            #:parse-macro
            #:enclose))
+
+(in-package #:trivial-cltl2)
+
+;;; This code is derived from 'clweb' by Alex Plotnick,
+;;; https://github.com/plotnick/clweb/blob/4c736b4c8b4c0afbdd939eefbcb986c16c24c1e3/clweb.lisp#L1853
+#+allegro
+(defun parse-macro (name lambda-list body &optional env)
+  (declare (ignorable name lambda-list body env))
+  (excl::defmacro-expander `(,name ,lambda-list ,@body) env))
+
+#+allegro
+(defun enclose (lambda-expression &optional environment)
+  (excl:compile-lambda-expr-in-env lambda-expression environment))


### PR DESCRIPTION
This pull request contains some fixes for Allegro Common Lisp.

* About `compiler-let`; Allegro Common Lisp has it in `excl` package, not in `system` package.
* About `parse-macro`; Allegro Common Lisp does not has it anywhere. I found an equivalent implementation from [clweb](https://github.com/plotnick/clweb). Because clweb is MIT license, I added the name of its author in comment.
* About `enclose`; Allegro Common Lisp does not has it also. I think Allegro's [excl:compile-lambda-expr-in-env](https://franz.com/support/documentation/10.1/doc/operators/excl/compile-lambda-expr-in-env.htm) has same functionality described in [CLtL2](https://www.cs.cmu.edu/Groups/AI/html/cltl/clm/node102.html) about `enclose`.