### PR TITLE
Fix for Allegro define-declaration (again)

### DIFF
--- a/allegro.lisp
+++ b/allegro.lisp
@@ -73,11 +73,13 @@ the CLtL2's function."
                (list (list (car second-value)
                            (cdr second-value))))))))
 
-(defmacro define-declaration (decl-name (decl-spec-arg env-arg) &body body)
+(defmacro define-declaration (decl-name lambda-list &body body)
   "Compatibility layer for Allegro's `system:define-declaration',
 which has very different arguments and return values from the CLtL2's one."
   ;; See https://franz.com/support/documentation/current/doc/operators/system/define-declaration.htm
-  (let ((guessed-kind (guess-declaration-kind-from-body body)))
+  (let ((guessed-kind (guess-declaration-kind-from-body body))
+        (decl-spec-arg (gensym "decl-spec-arg"))
+        (env-arg (gensym "env-arg")))
     (unless guessed-kind
       (warn "TRIVIAL-CLTL2:DEFINE-DECLARATION failed to guess the kind of declaration '~A'.
   Please use SYSTEM:DEFINE-DECLARATION for specifying exactly."
@@ -88,7 +90,11 @@ which has very different arguments and return values from the CLtL2's one."
        ,(or guessed-kind :both)         ; 'kind' argument.
        (lambda (,decl-spec-arg ,env-arg) ; 'def' argument.
          (multiple-value-call #'convert-allegro-define-declaration-result
-           (locally ,@body)))))) ; I use `locally' for accepting declarations in BODY.
+           ;; I use `lambda' for accepting a docstring and/or
+           ;; declarations in BODY.
+           ((lambda ,lambda-list ,@body)
+            ,decl-spec-arg
+            ,env-arg))))))
 
 ;;; This code is derived from 'clweb' by Alex Plotnick,
 ;;; https://github.com/plotnick/clweb/blob/4c736b4c8b4c0afbdd939eefbcb986c16c24c1e3/clweb.lisp#L1853


### PR DESCRIPTION
This pull request fixes my previous PR #5 .

I found a use case of `define-declaration` in [this slide](http://www.sbcl.org/sbcl20/slides/james-anderson-define-declaration.pdf) page 23. I quote it here:

```lisp
(define-declaration spocq.e:version-constraint (declaration &optional env)
  "Capture a temporal constraint which has been articulated in some reference to
 a pattern variable. Make it available for the BGP evaluation process to apply it to
 the statement matching process."
  (destructuring-bind (tag form) declaration
    (let ((old (when env (declaration-information 'spocq.e:version-constraint env))))
      ;; allow nil to shadow outer declarations in a sub-select
      (values :declare (cons tag (when form (cons form old)))))))
```

It has `&optional` in the lambda-list and a docstring in the body. Our `define-declaration` in #5 cannot accept them. So I fixed `define-declaration` for accepting them.

I confirmed other use cases in Quicklisp can be compiled. [1](https://github.com/guicho271828/trivia/blob/37698b47a14c2007630468de7a993694ef7bd475/level2/impl.lisp#L365) [2](https://github.com/numcl/gtype/blob/master/src/resolve.lisp#L51)

Sorry to bother you again.