### PR TITLE
Add CLASP support

### DIFF
--- a/cltl2.lisp
+++ b/cltl2.lisp
@@ -8,6 +8,7 @@
         #+sbcl #:sb-cltl2
         #+openmcl #:ccl
         #+cmu #:ext
+        #+clasp #:clasp-cltl2
         #+ecl #:si
         #+abcl #:lisp
         #+lispworks #:hcl)


### PR DESCRIPTION
Please not that `compiler-let` doesn't appear to be there yet.